### PR TITLE
tls: add cache limit and idle timeout to on-demand secret selector

### DIFF
--- a/api/envoy/extensions/transport_sockets/tls/cert_selectors/on_demand_secret/v3/config.proto
+++ b/api/envoy/extensions/transport_sockets/tls/cert_selectors/on_demand_secret/v3/config.proto
@@ -5,6 +5,9 @@ package envoy.extensions.transport_sockets.tls.cert_selectors.on_demand_secret.v
 import "envoy/config/core/v3/config_source.proto";
 import "envoy/config/core/v3/extension.proto";
 
+import "google/protobuf/duration.proto";
+import "google/protobuf/wrappers.proto";
+
 import "udpa/annotations/status.proto";
 import "validate/validate.proto";
 
@@ -41,4 +44,21 @@ message Config {
   // requests). The parent resource initializes immediately without waiting for the fetch to
   // complete.
   repeated string prefetch_secret_names = 3;
+
+  // The maximum number of secrets that the certificate selector will fetch and cache. Both the
+  // prefetched secrets and the secrets requested on-demand count towards the limit, and the
+  // configuration is rejected if the number of distinct
+  // :ref:`prefetch_secret_names <envoy_v3_api_field_extensions.transport_sockets.tls.cert_selectors.on_demand_secret.v3.Config.prefetch_secret_names>`
+  // exceeds it. When the cache is full, TLS handshakes that map to a secret name that is not
+  // already cached are rejected, while handshakes using cached secrets are unaffected. A cache
+  // slot is released when the SDS server removes the secret resource, canceling its subscription.
+  // If unset, defaults to 1024.
+  google.protobuf.UInt32Value max_secrets = 4 [(validate.rules).uint32 = {gt: 0}];
+
+  // The duration a cached secret can remain unused by any TLS handshake before it is evicted from
+  // the cache, canceling its SDS subscription. Idleness is evaluated periodically, so a secret may
+  // be evicted up to two times this duration after its last use. Prefetched secrets are never
+  // evicted due to idleness. If unset, cached secrets are only removed when the SDS server removes
+  // the secret resource or the parent listener or cluster is drained.
+  google.protobuf.Duration cache_idle_timeout = 5 [(validate.rules).duration = {gt {}}];
 }

--- a/changelogs/current/minor_behavior_changes/tls__on-demand-secret-cache-limit.rst
+++ b/changelogs/current/minor_behavior_changes/tls__on-demand-secret-cache-limit.rst
@@ -1,0 +1,7 @@
+The on-demand secret certificate selector now limits the number of fetched and cached secrets to 1024 by
+default, where previously the cache was unbounded. Handshakes that require fetching a new secret once the
+cache is full are rejected and counted in the ``cert_overflow`` counter. The limit can be adjusted with
+:ref:`max_secrets
+<envoy_v3_api_field_extensions.transport_sockets.tls.cert_selectors.on_demand_secret.v3.Config.max_secrets>`;
+deployments that require more than 1024 concurrently cached secrets should raise it accordingly (setting
+it to a very large value restores the previous unbounded behavior).

--- a/changelogs/current/new_features/tls__added-on-demand-secret-cache-limit.rst
+++ b/changelogs/current/new_features/tls__added-on-demand-secret-cache-limit.rst
@@ -1,0 +1,7 @@
+Added :ref:`max_secrets
+<envoy_v3_api_field_extensions.transport_sockets.tls.cert_selectors.on_demand_secret.v3.Config.max_secrets>`
+to bound the number of secrets fetched and cached by the on-demand secret certificate selector (1024 by
+default). When the cache is full, handshakes that require fetching a new secret are rejected and the
+``cert_overflow`` counter is incremented. Also added :ref:`cache_idle_timeout
+<envoy_v3_api_field_extensions.transport_sockets.tls.cert_selectors.on_demand_secret.v3.Config.cache_idle_timeout>`
+to evict cached secrets that are not used by any TLS handshake for the configured duration.

--- a/docs/root/configuration/security/secret.rst
+++ b/docs/root/configuration/security/secret.rst
@@ -299,6 +299,22 @@ plane. A resource removal sent via the xDS response will cancel the data plane s
 specific secret name. When using the regular GRPC xDS protocol, the subscription for each mapped
 secret remains active until the removal of the parent resource (listener or cluster).
 
+The number of secrets fetched and cached by the selector is bounded by the :ref:`max_secrets
+<envoy_v3_api_field_extensions.transport_sockets.tls.cert_selectors.on_demand_secret.v3.Config.max_secrets>`
+limit (1024 by default). This protects the memory usage of Envoy when the peers control the mapped
+secret name, e.g. via the SNI field. Once the limit is reached, handshakes that map to a secret
+name that is not already cached are rejected until a secret is removed to free a cache slot, while
+handshakes using cached secrets are unaffected.
+
+Cached secrets can be removed in three ways: the management server removes the resource (including
+by the expiry of the :ref:`resource TTL <xds_protocol_TTL>`, which is processed as a removal), the
+optional :ref:`cache_idle_timeout
+<envoy_v3_api_field_extensions.transport_sockets.tls.cert_selectors.on_demand_secret.v3.Config.cache_idle_timeout>`
+evicts secrets unused by any TLS handshake for the configured duration, or the parent listener or
+cluster is drained. Prefetched secrets are pinned in the cache and are not subject to idle
+eviction. Evicting a secret cancels its SDS subscription; connections that are already established
+with the certificate are not affected, and a later handshake for the same name fetches it again.
+
 In addition to the standard SDS `subscription statistics <subscription_statistics>`, the following
 statistics are produced by the on-demand certificate extension. For downstream listeners, they are
 in the *listener.<stat_prefix>.on_demand_secret.* namespace. For upstream clusters, the stat prefix
@@ -310,6 +326,8 @@ is *cluster.<stat_prefix>.on_demand_secret.*.
 
      cert_requested, Counter, Total number of new SDS subscriptions created
      cert_updated, Counter, Total number of certificate updates
+     cert_overflow, Counter, Total number of handshakes rejected due to the secret cache limit
+     cert_evicted, Counter, Total number of cached secrets evicted due to the cache idle timeout
      cert_active, Gauge, Number of active certificate subscriptions and certificates
 
 .. note::

--- a/source/extensions/transport_sockets/tls/cert_selectors/on_demand/config.cc
+++ b/source/extensions/transport_sockets/tls/cert_selectors/on_demand/config.cc
@@ -5,6 +5,8 @@
 #include "source/common/tls/context_impl.h"
 #include "source/server/generic_factory_context.h"
 
+#include "absl/container/flat_hash_set.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace TransportSockets {
@@ -72,18 +74,39 @@ SecretManager::SecretManager(const ConfigProto& config,
     : stats_scope_(factory_context.scope().createScope("on_demand_secret.")),
       stats_(generateCertSelectionStats(*stats_scope_)),
       factory_context_(factory_context.serverFactoryContext()),
-      config_source_(config.config_source()), context_factory_(std::move(context_factory)),
-      cert_contexts_(factory_context_.threadLocal()) {
+      config_source_(config.config_source()),
+      max_secrets_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, max_secrets, DefaultMaxSecrets)),
+      idle_timeout_(PROTOBUF_GET_OPTIONAL_MS(config, cache_idle_timeout)),
+      context_factory_(std::move(context_factory)), cert_contexts_(factory_context_.threadLocal()) {
   cert_contexts_.set([](Event::Dispatcher&) { return std::make_shared<ThreadLocalCerts>(); });
   for (const auto& name : config.prefetch_secret_names()) {
     addCertificateConfig(name, nullptr, factory_context.initManager());
+    cache_[name].prefetched_ = true;
+  }
+  if (idle_timeout_.has_value()) {
+    idle_timer_ = factory_context_.mainThreadDispatcher().createTimer([this] {
+      evictIdle();
+      idle_timer_->enableTimer(*idle_timeout_);
+    });
+    idle_timer_->enableTimer(*idle_timeout_);
   }
 }
 
 void SecretManager::addCertificateConfig(absl::string_view secret_name, HandleSharedPtr handle,
                                          OptRef<Init::Manager> init_manager) {
   ASSERT_IS_MAIN_OR_TEST_THREAD();
+  if (cache_.size() >= max_secrets_ && !cache_.contains(secret_name)) {
+    ENVOY_LOG_EVERY_POW_2(
+        warn, "On-demand secret cache is full at {} secrets, rejecting secret '{}'", cache_.size(),
+        secret_name);
+    stats_->cert_overflow_.inc();
+    if (handle) {
+      handle->notify(nullptr);
+    }
+    return;
+  }
   CacheEntry& entry = cache_[secret_name];
+  entry.recently_active_ = true;
   if (handle) {
     if (entry.cert_context_) {
       handle->notify(entry.cert_context_);
@@ -119,6 +142,7 @@ absl::Status SecretManager::updateCertificate(absl::string_view secret_name,
   setContext(secret_name, cert_context);
   CacheEntry& entry = cache_[secret_name];
   entry.cert_context_ = cert_context;
+  entry.recently_active_ = true;
   size_t notify_count = 0;
   for (const auto& fetch_handle : entry.callbacks_) {
     if (auto handle = fetch_handle.lock(); handle) {
@@ -181,6 +205,39 @@ void SecretManager::doRemoveCertificateConfig(absl::string_view secret_name) {
             secret_name, notify_count);
 }
 
+void SecretManager::evictIdle() {
+  ASSERT_IS_MAIN_OR_TEST_THREAD();
+  std::vector<std::string> idle_names;
+  for (auto& [secret_name, entry] : cache_) {
+    if (entry.prefetched_) {
+      continue;
+    }
+    if (entry.recently_active_) {
+      entry.recently_active_ = false;
+      continue;
+    }
+    if (entry.cert_context_ && entry.cert_context_->consumeUsed()) {
+      continue;
+    }
+    // Entries with live pending handshakes are in use.
+    bool in_use = false;
+    for (const auto& fetch_handle : entry.callbacks_) {
+      if (!fetch_handle.expired()) {
+        in_use = true;
+        break;
+      }
+    }
+    if (!in_use) {
+      idle_names.push_back(secret_name);
+    }
+  }
+  for (const auto& secret_name : idle_names) {
+    ENVOY_LOG(debug, "Evicting certificate '{}' after an idle timeout", secret_name);
+    stats_->cert_evicted_.inc();
+    doRemoveCertificateConfig(secret_name);
+  }
+}
+
 HandleSharedPtr SecretManager::fetchCertificate(absl::string_view secret_name,
                                                 Ssl::CertificateSelectionCallbackPtr&& cb,
                                                 bool client_ocsp_capable) {
@@ -220,6 +277,7 @@ SecretManager::getContext(absl::string_view secret_name) const {
   if (current) {
     const auto it = current->ctx_by_name_.find(secret_name);
     if (it != current->ctx_by_name_.end()) {
+      it->second->markUsed();
       return it->second;
     };
   }
@@ -287,6 +345,16 @@ createCertificateSelectorFactory(const Protobuf::Message& proto_config,
                                  AsyncContextFactory&& context_factory) {
   const ConfigProto& config = MessageUtil::downcastAndValidate<const ConfigProto&>(
       proto_config, factory_context.messageValidationVisitor());
+  const uint32_t max_secrets =
+      PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, max_secrets, DefaultMaxSecrets);
+  const absl::flat_hash_set<absl::string_view> prefetch_names(
+      config.prefetch_secret_names().begin(), config.prefetch_secret_names().end());
+  if (prefetch_names.size() > max_secrets) {
+    return absl::InvalidArgumentError(
+        fmt::format("The number of prefetched secrets ({}) exceeds the maximum number of "
+                    "cached secrets ({}).",
+                    prefetch_names.size(), max_secrets));
+  }
   MapperFactory& mapper_config =
       Config::Utility::getAndCheckFactory<MapperFactory>(config.certificate_mapper());
   ProtobufTypes::MessagePtr message = Config::Utility::translateAnyToFactoryConfig(

--- a/source/extensions/transport_sockets/tls/cert_selectors/on_demand/config.h
+++ b/source/extensions/transport_sockets/tls/cert_selectors/on_demand/config.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <atomic>
+
+#include "envoy/event/timer.h"
 #include "envoy/extensions/transport_sockets/tls/cert_selectors/on_demand_secret/v3/config.pb.h"
 #include "envoy/extensions/transport_sockets/tls/cert_selectors/on_demand_secret/v3/config.pb.validate.h"
 #include "envoy/registry/registry.h"
@@ -21,6 +24,8 @@ namespace OnDemand {
 #define ALL_CERT_SELECTION_STATS(COUNTER, GAUGE, HISTOGRAM)                                        \
   COUNTER(cert_requested)                                                                          \
   COUNTER(cert_updated)                                                                            \
+  COUNTER(cert_overflow)                                                                           \
+  COUNTER(cert_evicted)                                                                            \
   GAUGE(cert_active, Accumulate)
 
 struct CertSelectionStats {
@@ -37,6 +42,9 @@ using AsyncContextFactory = absl::AnyInvocable<AsyncContextConstSharedPtr(
 
 using ConfigProto =
     envoy::extensions::transport_sockets::tls::cert_selectors::on_demand_secret::v3::Config;
+
+// Default limit on the number of cached secrets when ``max_secrets`` is unset.
+inline constexpr uint32_t DefaultMaxSecrets = 1024;
 using UpdateCb = std::function<absl::Status(absl::string_view, const Ssl::TlsCertificateConfig&)>;
 using RemoveCb = std::function<absl::Status(absl::string_view)>;
 
@@ -83,8 +91,21 @@ public:
    */
   Stats::Scope& certScope() const { return *scope_; }
 
+  /**
+   * Mark the context as used by a handshake. May be called from any thread.
+   */
+  void markUsed() const { used_.store(true, std::memory_order_relaxed); }
+
+  /**
+   * @return whether the context was used since the last call, clearing the flag.
+   */
+  bool consumeUsed() const { return used_.exchange(false, std::memory_order_relaxed); }
+
 private:
   Stats::ScopeSharedPtr scope_;
+  // Tracks handshake usage for idle eviction. Starts as used so that a fresh certificate survives
+  // at least one full idle period.
+  mutable std::atomic<bool> used_{true};
 };
 
 class ServerAsyncContext : public AsyncContext,
@@ -211,17 +232,28 @@ public:
 
 private:
   void doRemoveCertificateConfig(absl::string_view);
+  void evictIdle();
   const Stats::ScopeSharedPtr stats_scope_;
   CertSelectionStatsSharedPtr stats_;
   Server::Configuration::ServerFactoryContext& factory_context_;
   const envoy::config::core::v3::ConfigSource config_source_;
+  // The maximum number of cache entries.
+  const uint32_t max_secrets_;
+  // The idle duration after which an unused cache entry is evicted, if configured.
+  const std::optional<std::chrono::milliseconds> idle_timeout_;
   AsyncContextFactory context_factory_;
+  Event::TimerPtr idle_timer_;
 
   // Main-thread accessible context config subscriptions and callbacks.
   struct CacheEntry {
     AsyncContextConfigConstPtr cert_config_;
     AsyncContextConstSharedPtr cert_context_;
     std::vector<std::weak_ptr<Handle>> callbacks_;
+    // Prefetched secrets are pinned in the cache and never evicted as idle.
+    bool prefetched_{false};
+    // Set on main-thread activity (creation, fetch attach, update) and cleared by each idle
+    // sweep, guaranteeing an entry survives at least one full idle period after any activity.
+    bool recently_active_{true};
   };
   absl::flat_hash_map<std::string, CacheEntry> cache_;
 

--- a/test/extensions/transport_sockets/tls/cert_selectors/on_demand/config_test.cc
+++ b/test/extensions/transport_sockets/tls/cert_selectors/on_demand/config_test.cc
@@ -88,6 +88,40 @@ TEST_F(OnDemandTest, BasicLoadTestStatefulResumption) {
   EXPECT_THAT(create(defaultConfig()), StatusIs(absl::StatusCode::kInvalidArgument));
 }
 
+TEST_F(OnDemandTest, MaxSecretsValid) {
+  EXPECT_OK(create(R"EOF(
+      config_source:
+        ads: {}
+      certificate_mapper:
+        name: static-name
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.cert_mappers.static_name.v3.StaticName
+          name: server
+      max_secrets: 1
+      cache_idle_timeout: 300s
+    )EOF"));
+}
+
+TEST_F(OnDemandTest, MaxSecretsPrefetchOverflow) {
+  auto factory = create(R"EOF(
+      config_source:
+        ads: {}
+      certificate_mapper:
+        name: static-name
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.cert_mappers.static_name.v3.StaticName
+          name: server
+      prefetch_secret_names:
+      - server
+      - server2
+      max_secrets: 1
+    )EOF");
+  EXPECT_THAT(factory, StatusIs(absl::StatusCode::kInvalidArgument));
+  EXPECT_THAT(factory.status().message(),
+              testing::HasSubstr("The number of prefetched secrets (2) exceeds the maximum number "
+                                 "of cached secrets (1)."));
+}
+
 TEST_F(OnDemandTest, QuicCall) {
   auto factory = create(defaultConfig());
   EXPECT_OK(factory);

--- a/test/extensions/transport_sockets/tls/cert_selectors/on_demand/integration_test.cc
+++ b/test/extensions/transport_sockets/tls/cert_selectors/on_demand/integration_test.cc
@@ -367,6 +367,146 @@ TEST_P(OnDemandIntegrationTest, BasicSuccessSNI) {
   EXPECT_EQ(0, test_server_->counter("sds.server.update_rejected")->value());
 }
 
+// Verifies that the cache limit rejects handshakes that require fetching new secrets while
+// handshakes using cached secrets are unaffected, and that a secret removal frees a cache slot.
+TEST_P(OnDemandIntegrationTest, MaxSecretsOverflow) {
+  if (upstream_selector_) {
+    GTEST_SKIP() << "SNI mapper only works on downstream";
+  }
+  ssl_options_.setSni("server");
+  setup(R"EOF(
+  certificate_mapper:
+    name: sni
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.cert_mappers.sni.v3.SNI
+      default_value: "*"
+  max_secrets: 1
+  )EOF");
+
+  // The first secret fills the cache to its limit.
+  auto conn = createClientConnection();
+  waitCertsRequested(1);
+  createXdsConnection();
+  auto& stream = waitSendSdsResponse("server");
+  conn->waitForUpstreamConnection();
+  conn->sendAndReceiveTlsData("hello", "world");
+  conn.reset();
+
+  // A handshake that maps to another secret name overflows the cache and is rejected.
+  ssl_options_.setSni("server2");
+  context_ = Ssl::createClientSslTransportSocketFactory(ssl_options_, *context_manager_, *api_);
+  auto conn2 = createClientConnection();
+  test_server_->waitForCounter(onDemandStat("cert_overflow"), Eq(1), TestUtility::DefaultTimeout,
+                               dispatcher_.get());
+  conn2->waitForDisconnect();
+  conn2.reset();
+  // The TCP proxy dials the upstream eagerly on accept, before the handshake resolves. Claim the
+  // rejected client's orphaned upstream connection so that subsequent connections observe their
+  // own upstream counterparts.
+  FakeRawConnectionPtr rejected_upstream;
+  ASSERT_TRUE(dataStream()->waitForRawConnection(rejected_upstream));
+  EXPECT_EQ(1, test_server_->counter(onDemandStat("cert_requested"))->value());
+  EXPECT_EQ(1, test_server_->gauge(onDemandStat("cert_active"))->value());
+
+  // The cached secret continues to be served.
+  ssl_options_.setSni("server");
+  context_ = Ssl::createClientSslTransportSocketFactory(ssl_options_, *context_manager_, *api_);
+  auto conn3 = createClientConnection();
+  conn3->waitForUpstreamConnection();
+  conn3->sendAndReceiveTlsData("hello", "world");
+  conn3.reset();
+
+  // Removing the cached secret frees a slot for the other secret name.
+  removeSecret(stream, "server");
+  test_server_->waitForGauge(onDemandStat("cert_active"), Eq(0));
+  ssl_options_.setSni("server2");
+  context_ = Ssl::createClientSslTransportSocketFactory(ssl_options_, *context_manager_, *api_);
+  auto conn4 = createClientConnection();
+  waitCertsRequested(2);
+  waitSendSdsResponse("server2");
+  conn4->waitForUpstreamConnection();
+  conn4->sendAndReceiveTlsData("hello", "world");
+  conn4.reset();
+  EXPECT_EQ(1, test_server_->gauge(onDemandStat("cert_active"))->value());
+}
+
+// Verifies that a secret unused by handshakes for the idle timeout is evicted, canceling its
+// subscription, and that a subsequent handshake fetches it again.
+TEST_P(OnDemandIntegrationTest, IdleTimeoutEviction) {
+  setup(R"EOF(
+  certificate_mapper:
+    name: static-name
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.cert_mappers.static_name.v3.StaticName
+      name: server
+  cache_idle_timeout: 0.2s
+  )EOF");
+  {
+    auto conn = createClientConnection();
+    if (upstream_selector_) {
+      conn->waitForUpstreamConnection();
+    }
+    waitCertsRequested(1);
+    createXdsConnection();
+    waitSendSdsResponse("server");
+    if (!upstream_selector_) {
+      conn->waitForUpstreamConnection();
+    }
+    conn->sendAndReceiveTlsData("hello", "world");
+    conn.reset();
+  }
+
+  // With no further handshakes, the secret is evicted after the idle timeout.
+  test_server_->waitForCounter(onDemandStat("cert_evicted"), Eq(1), TestUtility::DefaultTimeout,
+                               dispatcher_.get());
+  test_server_->waitForGauge(onDemandStat("cert_active"), Eq(0));
+
+  // The next handshake fetches the secret again.
+  {
+    auto conn = createClientConnection();
+    if (upstream_selector_) {
+      conn->waitForUpstreamConnection();
+    }
+    waitCertsRequested(2);
+    waitSendSdsResponse("server");
+    if (!upstream_selector_) {
+      conn->waitForUpstreamConnection();
+    }
+    conn->sendAndReceiveTlsData("hello", "world");
+    conn.reset();
+  }
+  EXPECT_EQ(1, test_server_->gauge(onDemandStat("cert_active"))->value());
+}
+
+// Verifies that prefetched secrets are pinned in the cache and not evicted as idle.
+TEST_P(OnDemandIntegrationTest, IdleTimeoutPrefetchPinned) {
+  on_server_init_function_ = [&]() {
+    createXdsConnection();
+    waitSendSdsResponse("server");
+  };
+  setup(R"EOF(
+  certificate_mapper:
+    name: static-name
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.cert_mappers.static_name.v3.StaticName
+      name: server
+  prefetch_secret_names:
+  - server
+  cache_idle_timeout: 0.2s
+  )EOF");
+  // Allow several idle periods to elapse without any handshake.
+  timeSystem().realSleepDoNotUseWithoutScrutiny(std::chrono::milliseconds(600));
+  EXPECT_EQ(0, test_server_->counter(onDemandStat("cert_evicted"))->value());
+  EXPECT_EQ(1, test_server_->gauge(onDemandStat("cert_active"))->value());
+
+  // The prefetched secret still serves handshakes.
+  auto conn = createClientConnection();
+  conn->waitForUpstreamConnection();
+  conn->sendAndReceiveTlsData("hello", "world");
+  conn.reset();
+  EXPECT_EQ(1, test_server_->counter(onDemandStat("cert_requested"))->value());
+}
+
 TEST_P(OnDemandIntegrationTest, BasicSuccessMixed) {
   setup(R"EOF(
   certificate_mapper:


### PR DESCRIPTION
Commit Message: tls: add cache limit and idle timeout to on-demand secret selector

Additional Description:
The on-demand secret certificate selector cache previously grew without bound: every unique mapped secret name (e.g. peer-controlled SNI) created a cache entry and a dedicated SDS subscription. This adds two bounds:

- `max_secrets` (default 1024, matching the dynamic forward proxy `max_hosts` default): caps the number of fetched and cached secrets per selector. When the cache is full, handshakes that map to a not-yet-cached secret name are rejected (new `cert_overflow` counter, rate-limited warn log), while handshakes using cached secrets are unaffected. A slot is freed when the SDS server removes the resource, including via xDS resource TTL expiry. The configuration is rejected if the number of distinct `prefetch_secret_names` exceeds the limit.
- `cache_idle_timeout` (optional, disabled by default): evicts secrets unused by any TLS handshake for the configured duration, canceling their SDS subscriptions. Use is tracked with a relaxed atomic flag marked on worker-thread cache hits and swept by a main-thread timer, so eviction occurs between 1x and 2x the timeout after last use. Prefetched secrets are pinned; entries with pending handshakes are never evicted. Evictions are counted in the new `cert_evicted` counter.

This PR was written with AI assistance and reviewed by the author.

Risk Level: medium (new default cache limit on an existing extension; deployments with more than 1024 concurrently cached on-demand secrets must raise `max_secrets`)
Testing: unit tests (config validation) and integration tests (overflow rejection and slot recycling, idle eviction and re-fetch, prefetch pinning)
Docs Changes: docs/root/configuration/security/secret.rst updated with the cache bounds, removal paths, and new stats
Release Notes: new_features and minor_behavior_changes entries included
Platform Specific Features: n/a
