### PR TITLE
formatter: add formatTo() sink API to avoid per-request allocations

### DIFF
--- a/envoy/formatter/substitution_formatter.h
+++ b/envoy/formatter/substitution_formatter.h
@@ -35,6 +35,20 @@ public:
    */
   virtual std::string format(const Context& context,
                              const StreamInfo::StreamInfo& stream_info) const PURE;
+
+  /**
+   * Append the formatted substitution line to the given sink. Callers that format repeatedly
+   * can hand in a reused buffer and avoid the allocation that format() performs on every call.
+   * Implementations that build the line incrementally should override this; the default simply
+   * appends the result of format().
+   * @param sink supplies the string the substitution line is appended to.
+   * @param context supplies the formatter context.
+   * @param stream_info supplies the stream info.
+   */
+  virtual void formatTo(std::string& sink, const Context& context,
+                        const StreamInfo::StreamInfo& stream_info) const {
+    sink.append(format(context, stream_info));
+  }
 };
 
 using FormatterPtr = std::unique_ptr<Formatter>;
@@ -56,6 +70,26 @@ public:
    */
   virtual std::optional<std::string> format(const Context& context,
                                             const StreamInfo::StreamInfo& stream_info) const PURE;
+
+  /**
+   * Append the extracted value to the given sink. This is the allocation-free counterpart of
+   * format() and should be overridden by providers that can write their value directly into the
+   * sink. The default implementation appends the result of format().
+   * @param sink supplies the string the value is appended to. It is left unmodified if no value
+   *        is extracted.
+   * @param context supplies the formatter context.
+   * @param stream_info supplies the stream info.
+   * @return bool true if a value was extracted and appended to the sink.
+   */
+  virtual bool formatTo(std::string& sink, const Context& context,
+                        const StreamInfo::StreamInfo& stream_info) const {
+    const std::optional<std::string> value = format(context, stream_info);
+    if (!value.has_value()) {
+      return false;
+    }
+    sink.append(*value);
+    return true;
+  }
 
   /**
    * Format the value with the given context and stream info.

--- a/source/common/formatter/http_specific_formatter.cc
+++ b/source/common/formatter/http_specific_formatter.cc
@@ -81,6 +81,17 @@ std::optional<std::string> HeaderFormatter::format(OptRef<const Http::HeaderMap>
   return std::string(val);
 }
 
+bool HeaderFormatter::formatTo(std::string& sink, OptRef<const Http::HeaderMap> headers) const {
+  const Http::HeaderEntry* header = findHeader(headers);
+  if (!header) {
+    return false;
+  }
+
+  absl::string_view val = header->value().getStringView();
+  sink.append(SubstitutionFormatUtils::truncateStringView(val, max_length_));
+  return true;
+}
+
 Protobuf::Value HeaderFormatter::formatValue(OptRef<const Http::HeaderMap> headers) const {
   const Http::HeaderEntry* header = findHeader(headers);
   if (!header) {
@@ -102,6 +113,11 @@ std::optional<std::string> ResponseHeaderFormatter::format(const Context& contex
   return HeaderFormatter::format(context.responseHeaders());
 }
 
+bool ResponseHeaderFormatter::formatTo(std::string& sink, const Context& context,
+                                       const StreamInfo::StreamInfo&) const {
+  return HeaderFormatter::formatTo(sink, context.responseHeaders());
+}
+
 Protobuf::Value ResponseHeaderFormatter::formatValue(const Context& context,
                                                      const StreamInfo::StreamInfo&) const {
   return HeaderFormatter::formatValue(context.responseHeaders());
@@ -117,6 +133,11 @@ std::optional<std::string> RequestHeaderFormatter::format(const Context& context
   return HeaderFormatter::format(context.requestHeaders());
 }
 
+bool RequestHeaderFormatter::formatTo(std::string& sink, const Context& context,
+                                      const StreamInfo::StreamInfo&) const {
+  return HeaderFormatter::formatTo(sink, context.requestHeaders());
+}
+
 Protobuf::Value RequestHeaderFormatter::formatValue(const Context& context,
                                                     const StreamInfo::StreamInfo&) const {
   return HeaderFormatter::formatValue(context.requestHeaders());
@@ -130,6 +151,11 @@ ResponseTrailerFormatter::ResponseTrailerFormatter(absl::string_view main_header
 std::optional<std::string> ResponseTrailerFormatter::format(const Context& context,
                                                             const StreamInfo::StreamInfo&) const {
   return HeaderFormatter::format(context.responseTrailers());
+}
+
+bool ResponseTrailerFormatter::formatTo(std::string& sink, const Context& context,
+                                        const StreamInfo::StreamInfo&) const {
+  return HeaderFormatter::formatTo(sink, context.responseTrailers());
 }
 
 Protobuf::Value ResponseTrailerFormatter::formatValue(const Context& context,

--- a/source/common/formatter/http_specific_formatter.h
+++ b/source/common/formatter/http_specific_formatter.h
@@ -54,6 +54,7 @@ public:
 
 protected:
   std::optional<std::string> format(OptRef<const Http::HeaderMap> headers) const;
+  bool formatTo(std::string& sink, OptRef<const Http::HeaderMap> headers) const;
   Protobuf::Value formatValue(OptRef<const Http::HeaderMap> headers) const;
 
 private:
@@ -97,6 +98,8 @@ public:
   // FormatterProvider
   std::optional<std::string> format(const Context& context,
                                     const StreamInfo::StreamInfo& stream_info) const override;
+  bool formatTo(std::string& sink, const Context& context,
+                const StreamInfo::StreamInfo& stream_info) const override;
   Protobuf::Value formatValue(const Context& context,
                               const StreamInfo::StreamInfo& stream_info) const override;
 };
@@ -112,6 +115,8 @@ public:
   // FormatterProvider
   std::optional<std::string> format(const Context& context,
                                     const StreamInfo::StreamInfo& stream_info) const override;
+  bool formatTo(std::string& sink, const Context& context,
+                const StreamInfo::StreamInfo& stream_info) const override;
   Protobuf::Value formatValue(const Context& context,
                               const StreamInfo::StreamInfo& stream_info) const override;
 };
@@ -127,6 +132,8 @@ public:
   // FormatterProvider
   std::optional<std::string> format(const Context& context,
                                     const StreamInfo::StreamInfo& stream_info) const override;
+  bool formatTo(std::string& sink, const Context& context,
+                const StreamInfo::StreamInfo& stream_info) const override;
   Protobuf::Value formatValue(const Context& context,
                               const StreamInfo::StreamInfo& stream_info) const override;
 };

--- a/source/common/formatter/substitution_formatter.cc
+++ b/source/common/formatter/substitution_formatter.cc
@@ -383,36 +383,43 @@ FormatterImpl::create(absl::string_view format, bool omit_empty_values,
 std::string FormatterImpl::format(const Context& context,
                                   const StreamInfo::StreamInfo& stream_info) const {
   std::string log_line;
-  log_line.reserve(256);
+  log_line.reserve(constant_value_.has_value() ? constant_value_->size() : 256);
+  formatTo(log_line, context, stream_info);
+  return log_line;
+}
 
-  for (const auto& provider : providers_) {
-    const std::optional<std::string> bit = provider->format(context, stream_info);
-    // Add the formatted value if there is one. Otherwise add a default value
-    // of "-" if omit_empty_values_ is not set.
-    if (bit.has_value()) {
-      log_line += bit.value();
-    } else if (!omit_empty_values_) {
-      log_line += DefaultUnspecifiedValueStringView;
-    }
+void FormatterImpl::formatTo(std::string& sink, const Context& context,
+                             const StreamInfo::StreamInfo& stream_info) const {
+  if (constant_value_.has_value()) {
+    sink.append(*constant_value_);
+    return;
   }
 
-  return log_line;
+  for (const auto& provider : providers_) {
+    // Add the formatted value if there is one. Otherwise add a default value
+    // of "-" if omit_empty_values_ is not set.
+    if (!provider->formatTo(sink, context, stream_info) && !omit_empty_values_) {
+      sink.append(DefaultUnspecifiedValueStringView);
+    }
+  }
 }
 
 void stringValueToLogLine(const JsonFormatterImpl::Formatters& formatters, const Context& context,
                           const StreamInfo::StreamInfo& info, std::string& log_line,
-                          std::string& sanitize, bool omit_empty_values) {
+                          std::string& value, std::string& sanitize, bool omit_empty_values) {
   log_line.push_back('"'); // Start the JSON string.
   for (const JsonFormatterImpl::Formatter& formatter : formatters) {
-    const std::optional<std::string> value = formatter->format(context, info);
-    if (!value.has_value()) {
+    // 'value' is owned by the caller and reused for every provider of every field in the line,
+    // so formatting a value stops allocating once it has grown to fit the widest one.
+    value.clear();
+    if (!formatter->formatTo(value, context, info)) {
       // Add the empty value. This needn't be sanitized.
       log_line.append(omit_empty_values ? EMPTY_STRING : DefaultUnspecifiedValueStringView);
       continue;
     }
     // Sanitize the string value and add it to the buffer. The string value will not be quoted
     // since we handle the quoting by ourselves at the outer level.
-    log_line.append(Json::sanitize(sanitize, value.value()));
+    log_line.append(Json::sanitize(sanitize, value));
   }
   log_line.push_back('"'); // End the JSON string.
 }
@@ -442,6 +449,13 @@ std::string JsonFormatterImpl::format(const Context& context,
                                       const StreamInfo::StreamInfo& info) const {
   std::string log_line;
   log_line.reserve(2048);
+  formatTo(log_line, context, info);
+  return log_line;
+}
+
+void JsonFormatterImpl::formatTo(std::string& sink, const Context& context,
+                                 const StreamInfo::StreamInfo& info) const {
+  std::string value;    // Helper to hold the formatted value of a single provider.
   std::string sanitize; // Helper to serialize the value to log line.
 
   for (const ParsedFormatElement& element : parsed_elements_) {
@@ -449,7 +463,7 @@ std::string JsonFormatterImpl::format(const Context& context,
     if (absl::holds_alternative<std::string>(element)) {
       // The raw string element will be added to the buffer directly.
       // It is sanitized when loading the configuration.
-      log_line.append(absl::get<std::string>(element));
+      sink.append(absl::get<std::string>(element));
       continue;
     }
 
@@ -459,17 +473,16 @@ std::string JsonFormatterImpl::format(const Context& context,
 
     if (formatters.size() != 1) {
       // 2. Handle the formatter element with multiple or zero providers.
-      stringValueToLogLine(formatters, context, info, log_line, sanitize, omit_empty_values_);
+      stringValueToLogLine(formatters, context, info, sink, value, sanitize, omit_empty_values_);
     } else {
       // 3. Handle the formatter element with a single provider and value
       //    type needs to be kept.
-      const auto value = formatters[0]->formatValue(context, info);
-      Json::Utility::appendValueToString(value, log_line);
+      const auto json_value = formatters[0]->formatValue(context, info);
+      Json::Utility::appendValueToString(json_value, sink);
     }
   }
 
-  log_line.push_back('\n');
-  return log_line;
+  sink.push_back('\n');
 }
 
 // A JSON array node in the format template tree used by OmitEmptyJsonFormatterImpl.
@@ -579,7 +592,7 @@ buildJsonFormatMapNode(const ProtoDict& fields, const std::vector<CommandParserP
 
 bool serializeJsonFormatValue(const JsonFormatValue& value, const Context& context,
                               const StreamInfo::StreamInfo& info, JsonStringSerializer& serializer,
-                              std::string& buffer, std::string& sanitize);
+                              std::string& buffer, std::string& scratch, std::string& sanitize);
 
 // Serializes a map node into the output buffer. Returns true if the node produced any output. A
 // node whose fields are all omitted produces no output and returns false so that its parent (or
@@ -587,7 +600,7 @@ bool serializeJsonFormatValue(const JsonFormatValue& value, const Context& conte
 bool serializeJsonFormatMapNode(const JsonFormatMapNode& node, const Context& context,
                                 const StreamInfo::StreamInfo& info,
                                 JsonStringSerializer& serializer, std::string& buffer,
-                                std::string& sanitize) {
+                                std::string& scratch, std::string& sanitize) {
   const size_t node_start = buffer.size();
   serializer.addMapBeginDelimiter();
   bool object_is_empty = true;
@@ -598,7 +611,8 @@ bool serializeJsonFormatMapNode(const JsonFormatMapNode& node, const Context& co
     }
     serializer.addString(field.first);
     serializer.addKeyValueDelimiter();
-    if (!serializeJsonFormatValue(field.second, context, info, serializer, buffer, sanitize)) {
+    if (!serializeJsonFormatValue(field.second, context, info, serializer, buffer, scratch,
+                                  sanitize)) {
       // The value was omitted; roll back the element delimiter, key and any partial output.
       buffer.resize(field_start);
       continue;
@@ -619,7 +633,7 @@ bool serializeJsonFormatMapNode(const JsonFormatMapNode& node, const Context& co
 void serializeJsonFormatListNode(const JsonFormatListNode& node, const Context& context,
                                  const StreamInfo::StreamInfo& info,
                                  JsonStringSerializer& serializer, std::string& buffer,
-                                 std::string& sanitize) {
+                                 std::string& scratch, std::string& sanitize) {
   serializer.addArrayBeginDelimiter();
   bool array_is_empty = true;
   for (const JsonFormatValue& element : node.values_) {
@@ -627,7 +641,7 @@ void serializeJsonFormatListNode(const JsonFormatListNode& node, const Context& 
     if (!array_is_empty) {
       serializer.addElementsDelimiter();
     }
-    if (!serializeJsonFormatValue(element, context, info, serializer, buffer, sanitize)) {
+    if (!serializeJsonFormatValue(element, context, info, serializer, buffer, scratch, sanitize)) {
       buffer.resize(element_start);
       continue;
     }
@@ -638,7 +652,7 @@ void serializeJsonFormatListNode(const JsonFormatListNode& node, const Context& 
 
 bool serializeJsonFormatValue(const JsonFormatValue& value, const Context& context,
                               const StreamInfo::StreamInfo& info, JsonStringSerializer& serializer,
-                              std::string& buffer, std::string& sanitize) {
+                              std::string& buffer, std::string& scratch, std::string& sanitize) {
   // A pre-serialized constant scalar is emitted directly.
   if (absl::holds_alternative<std::string>(value)) {
     serializer.addRawString(absl::get<std::string>(value));
@@ -647,12 +661,12 @@ bool serializeJsonFormatValue(const JsonFormatValue& value, const Context& conte
   // A nested object; it is dropped if all of its fields are omitted.
   if (absl::holds_alternative<JsonFormatMapNode>(value)) {
     return serializeJsonFormatMapNode(absl::get<JsonFormatMapNode>(value), context, info,
-                                      serializer, buffer, sanitize);
+                                      serializer, buffer, scratch, sanitize);
   }
   // A nested array; it is always kept, even when empty.
   if (absl::holds_alternative<JsonFormatListNode>(value)) {
     serializeJsonFormatListNode(absl::get<JsonFormatListNode>(value), context, info, serializer,
-                                buffer, sanitize);
+                                buffer, scratch, sanitize);
     return true;
   }
 
@@ -674,7 +688,8 @@ bool serializeJsonFormatValue(const JsonFormatValue& value, const Context& conte
 
   // Multiple providers force a string output which is always kept, even if empty. Missing values
   // contribute an empty string because omit_empty_values is set.
-  stringValueToLogLine(formatters, context, info, buffer, sanitize, /*omit_empty_values=*/true);
+  stringValueToLogLine(formatters, context, info, buffer, scratch, sanitize,
+                       /*omit_empty_values=*/true);
   return true;
 }
 
@@ -699,9 +714,10 @@ std::string OmitEmptyJsonFormatterImpl::format(const Context& context,
                                                const StreamInfo::StreamInfo& info) const {
   std::string log_line;
   log_line.reserve(2048);
+  std::string scratch;  // Helper to hold the formatted value of a single provider.
   std::string sanitize; // Helper to serialize the value to log line.
   JsonStringSerializer serializer(log_line);
-  if (!serializeJsonFormatMapNode(*root_, context, info, serializer, log_line, sanitize)) {
+  if (!serializeJsonFormatMapNode(*root_, context, info, serializer, log_line, scratch, sanitize)) {
     // Every field was omitted; the root object is always emitted as an empty object.
     serializer.addMapBeginDelimiter();
     serializer.addMapEndDelimiter();

--- a/source/common/formatter/substitution_formatter.h
+++ b/source/common/formatter/substitution_formatter.h
@@ -37,6 +37,10 @@ public:
   std::optional<std::string> format(const Context&, const StreamInfo::StreamInfo&) const override {
     return str_.string_value();
   }
+  bool formatTo(std::string& sink, const Context&, const StreamInfo::StreamInfo&) const override {
+    sink.append(str_.string_value());
+    return true;
+  }
   Protobuf::Value formatValue(const Context&, const StreamInfo::StreamInfo&) const override {
     return str_;
   }
@@ -90,17 +94,28 @@ public:
   // Formatter
   std::string format(const Context& context,
                      const StreamInfo::StreamInfo& stream_info) const override;
+  void formatTo(std::string& sink, const Context& context,
+                const StreamInfo::StreamInfo& stream_info) const override;
 
 protected:
   FormatterImpl(absl::Status& creation_status, absl::string_view format,
                 bool omit_empty_values = false, const CommandParsers& command_parsers = {})
       : omit_empty_values_(omit_empty_values) {
+    // Substitution commands are always introduced by a '%', so a format string without one is a
+    // constant that is known at configuration time. Parsing it would only ever produce a single
+    // string literal provider that format() and formatTo() would then never consult, so fold the
+    // value here and skip the parse entirely.
+    if (format.find('%') == absl::string_view::npos) {
+      constant_value_.emplace(format);
+      return;
+    }
     auto providers_or_error = SubstitutionFormatParser::parse(format, command_parsers);
     SET_AND_RETURN_IF_NOT_OK(providers_or_error.status(), creation_status);
     providers_ = std::move(*providers_or_error);
   }
 
 private:
+  std::optional<std::string> constant_value_;
   const bool omit_empty_values_;
   std::vector<FormatterProviderPtr> providers_;
 };
@@ -120,6 +135,8 @@ public:
 
   // Formatter
   std::string format(const Context& context, const StreamInfo::StreamInfo& info) const override;
+  void formatTo(std::string& sink, const Context& context,
+                const StreamInfo::StreamInfo& info) const override;
 
 private:
   const bool omit_empty_values_;

--- a/source/common/http/header_mutation.cc
+++ b/source/common/http/header_mutation.cc
@@ -24,7 +24,16 @@ public:
 
   void evaluateHeaders(Http::HeaderMap& headers, const Formatter::Context& context,
                        const StreamInfo::StreamInfo& stream_info) const override {
-    const std::string value = formatter_->format(context, stream_info);
+    std::string value_buffer;
+    absl::string_view value;
+    if (formatter_ != nullptr) {
+      formatter_->formatTo(value_buffer, context, stream_info);
+      value = value_buffer;
+    } else {
+      // The configured value contains no substitution command, so no formatter was built for it
+      // and it evaluates to itself.
+      value = original_value_;
+    }
 
     if (!value.empty() || add_if_empty_) {
       switch (append_action_) {

--- a/source/common/router/header_parser.cc
+++ b/source/common/router/header_parser.cc
@@ -23,6 +23,9 @@ namespace Router {
 
 namespace {
 
+// Returns the formatter for the given header value, or nullptr if the value contains no
+// substitution command. Such a value formats to itself for every request, so callers use it
+// directly and no formatter is built for it.
 absl::StatusOr<Formatter::FormatterPtr>
 parseHttpHeaderFormatter(const envoy::config::core::v3::HeaderValue& header_value,
                          const Formatter::CommandParserPtrVector& command_parsers) {
@@ -38,6 +41,13 @@ parseHttpHeaderFormatter(const envoy::config::core::v3::HeaderValue& header_valu
   // HTTP/1 and HTTP/2. It could arguably be allowed on the response path.
   if (!Http::HeaderUtility::isModifiableHeader(key)) {
     return absl::InvalidArgumentError(":-prefixed or host headers may not be modified");
+  }
+
+  // Substitution commands are always introduced by a '%'. Without one the value is a constant,
+  // and the translations below only rewrite '%'-delimited commands, so they would leave it
+  // unchanged too. Skip building a formatter that would only ever echo the configured value.
+  if (header_value.value().find('%') == std::string::npos) {
+    return nullptr;
   }
 
   if (!Runtime::runtimeFeatureEnabled("envoy.reloadable_features.remove_legacy_route_formatter")) {
@@ -177,17 +187,22 @@ void HeaderParser::evaluateHeaders(Http::HeaderMap& headers, const Formatter::Co
   // value_buffer is used only when stream_info is a valid pointer and stores header value
   // created by a formatter. It is declared outside of 'for' loop for performance reason to avoid
   // stack allocation and unnecessary std::string's memory adjustments for each iteration. The
-  // actual value of the header is accessed via 'value' variable which is initialized differently
+  // formatter appends into it via formatTo() rather than returning a new string, so once the
+  // buffer has grown to fit the widest header value no further allocation happens. The actual
+  // value of the header is accessed via 'value' variable which is initialized differently
   // depending whether stream_info and valid or nullptr. Based on performance tests implemented in
   // header_formatter_speed_test.cc this approach strikes the best balance between performance and
   // readability.
   std::string value_buffer;
   for (const auto& [key, entry] : headers_to_add_) {
     absl::string_view value;
-    if (stream_info != nullptr) {
-      value_buffer = entry->formatter_->format(context, *stream_info);
+    if (stream_info != nullptr && entry->formatter_ != nullptr) {
+      value_buffer.clear();
+      entry->formatter_->formatTo(value_buffer, context, *stream_info);
       value = value_buffer;
     } else {
+      // Either there is no stream to evaluate against, or the configured value is a constant and
+      // no formatter was built for it.
       value = entry->original_value_;
     }
     if (!value.empty() || entry->add_if_empty_) {
@@ -230,7 +245,9 @@ Http::HeaderTransforms HeaderParser::getHeaderTransforms(const StreamInfo::Strea
 
   for (const auto& [key, entry] : headers_to_add_) {
     if (do_formatting) {
-      const std::string value = entry->formatter_->format({}, stream_info);
+      const std::string value = entry->formatter_ != nullptr
+                                    ? entry->formatter_->format({}, stream_info)
+                                    : entry->original_value_;
       if (!value.empty() || entry->add_if_empty_) {
         switch (entry->append_action_) {
         case HeaderValueOption::APPEND_IF_EXISTS_OR_ADD:

--- a/source/common/router/header_parser.h
+++ b/source/common/router/header_parser.h
@@ -43,6 +43,8 @@ struct HeadersToAddEntry {
   }
 
   std::string original_value_;
+  // Null when the configured value contains no substitution command. Such a value formats to
+  // original_value_ for every request, so no formatter is built and callers use that directly.
   Formatter::FormatterPtr formatter_;
   HeaderAppendAction append_action_;
   // Keep small members (bools and enums) at the end of class, to reduce alignment overhead.

--- a/test/common/router/BUILD
+++ b/test/common/router/BUILD
@@ -626,6 +626,7 @@ envoy_cc_benchmark_binary(
     srcs = ["header_formatter_speed_test.cc"],
     rbe_pool = "6gig",
     deps = [
+        "//source/common/formatter:formatter_extension_lib",
         "//source/common/router:router_lib",
         "//test/common/stream_info:test_util",
         "@benchmark",

--- a/test/common/router/header_formatter_speed_test.cc
+++ b/test/common/router/header_formatter_speed_test.cc
@@ -46,5 +46,66 @@ static void bmEvaluateHeaders(benchmark::State& state) {
 
 BENCHMARK(bmEvaluateHeaders)->DenseRange(2, 20, 2);
 
+// bmEvaluateHeaders uses APPEND_IF_EXISTS_OR_ADD for half of the headers, so the header map it
+// evaluates against grows on every iteration and the measurement includes that growth. The two
+// benchmarks below use OVERWRITE_IF_EXISTS_OR_ADD exclusively, which keeps the header map at a
+// fixed size and isolates the cost of evaluating the headers themselves. They differ only in
+// whether the header value is a constant or a substitution command.
+static void bmEvaluateHeadersConstant(benchmark::State& state) {
+  auto request_header = Http::RequestHeaderMapImpl::create();
+  request_header->addCopy(Http::LowerCaseString("x-source"),
+                          "0123456789012345678901234567890123456789");
+
+  Event::SimulatedTimeSystem time_system;
+  const auto stream_info = std::make_unique<Envoy::TestStreamInfo>(time_system);
+
+  Protobuf::RepeatedPtrField<envoy::config::core::v3::HeaderValueOption> headers_to_add;
+  for (auto i = 1; i < state.range(0); i++) {
+    envoy::config::core::v3::HeaderValueOption* header_value_option = headers_to_add.Add();
+    auto* mutable_header = header_value_option->mutable_header();
+    header_value_option->set_append_action(HeaderValueOption::OVERWRITE_IF_EXISTS_OR_ADD);
+    mutable_header->set_key(fmt::format("test{}", i));
+    mutable_header->set_value("0123456789012345678901234567890123456789");
+  }
+
+  HeaderParserPtr header_parser = HeaderParser::configure(headers_to_add).value();
+
+  for (auto _ : state) { // NOLINT: Silences warning about dead store
+    header_parser->evaluateHeaders(*request_header, {request_header.get()}, *stream_info);
+  }
+}
+
+BENCHMARK(bmEvaluateHeadersConstant)->DenseRange(2, 20, 2);
+
+// Same as bmEvaluateHeadersConstant, but every header value is a substitution command that has to
+// be evaluated against the stream for each request. The source header value is deliberately longer
+// than the std::string small-string buffer, which is the common case for real headers and the case
+// where copying the formatted value out of the formatter is most expensive.
+static void bmEvaluateHeadersDynamic(benchmark::State& state) {
+  auto request_header = Http::RequestHeaderMapImpl::create();
+  request_header->addCopy(Http::LowerCaseString("x-source"),
+                          "0123456789012345678901234567890123456789");
+
+  Event::SimulatedTimeSystem time_system;
+  const auto stream_info = std::make_unique<Envoy::TestStreamInfo>(time_system);
+
+  Protobuf::RepeatedPtrField<envoy::config::core::v3::HeaderValueOption> headers_to_add;
+  for (auto i = 1; i < state.range(0); i++) {
+    envoy::config::core::v3::HeaderValueOption* header_value_option = headers_to_add.Add();
+    auto* mutable_header = header_value_option->mutable_header();
+    header_value_option->set_append_action(HeaderValueOption::OVERWRITE_IF_EXISTS_OR_ADD);
+    mutable_header->set_key(fmt::format("test{}", i));
+    mutable_header->set_value("%REQ(x-source)%");
+  }
+
+  HeaderParserPtr header_parser = HeaderParser::configure(headers_to_add).value();
+
+  for (auto _ : state) { // NOLINT: Silences warning about dead store
+    header_parser->evaluateHeaders(*request_header, {request_header.get()}, *stream_info);
+  }
+}
+
+BENCHMARK(bmEvaluateHeadersDynamic)->DenseRange(2, 20, 2);
+
 } // namespace Router
 } // namespace Envoy


### PR DESCRIPTION
Commit Message: formatter: add formatTo() sink API to avoid per-request allocations

Additional Description:

`FormatterImpl::format()` always reserved 256 bytes and every `FormatterProvider` returned
`std::optional<std::string>`, so each configured header cost an allocation plus several
copies per request, even for a constant value.

Add `formatTo(std::string&)` to `Formatter` and `FormatterProvider` so callers can format
into a buffer they reuse. Both are virtual and default to the existing `format()`, so
out-of-tree providers are unaffected. `FormatterImpl` also folds a format string with no
`%` into a constant at config time, letting `HeaderParser` skip the formatter for static
`headers_to_add`.

### Benchmarks

`-c opt`, base and new run alternately in pairs to cancel host noise.
`BM_FormatterCommandParsing` is a control over untouched code.

```
                                   base (ns)   new (ns)    delta
----------------------------------------------------------------
bmEvaluateHeaders/20                  1581.3     1186.0   -25.9%
bmEvaluateHeadersConstant/20          2903.1     2091.2   -27.8%
bmEvaluateHeadersDynamic/20           3079.1     2450.9   -19.3%
                       (DenseRange(2,20,2): -18% .. -40%)

BM_AccessLogFormatter                  147.4      138.7    -5.9%
BM_FormatterCommandParsing [ctrl]       26.9       26.5    -3.0%
```

~42 ns saved per constant header, ~36 ns per `%REQ(...)%` header. Access log formatting is
unchanged within noise: `format()` still returns a string, so only the per-provider
`std::optional` went away.

Risk Level: Low — no functional or configuration change.

Testing: `substitution_formatter_test`, `substitution_format_string_test`,
`header_formatter_test` and `config_impl_test` pass in fastbuild and at `-c opt`. Two
benchmark cases added (`bmEvaluateHeadersConstant`, `bmEvaluateHeadersDynamic`).

Docs Changes: N/A

Release Notes: N/A

Platform Specific Features: N/A

---

